### PR TITLE
enforce slurm and munge uid/gid

### DIFF
--- a/bicep/files-to-load/slurm-workspace.txt
+++ b/bicep/files-to-load/slurm-workspace.txt
@@ -31,6 +31,10 @@ Autoscale = $Autoscale
         slurm.autoscale_pkg = azure-slurm-pkg-3.0.6.tar.gz
 
         slurm.version = $configuration_slurm_version
+        slurm.user.uid = 11100
+        slurm.user.gid = 11100
+        munge.user.uid = 11101
+        munge.user.gid = 11101
         slurm.accounting.enabled = $configuration_slurm_accounting_enabled
         slurm.accounting.url = $configuration_slurm_accounting_url
         slurm.accounting.user = $configuration_slurm_accounting_user


### PR DESCRIPTION
this is to fix the security violation error when the scheduler is on alma and the execute nodes are on ubuntu.