### PR TITLE
Updated NFS selection dropdown for builtin NFS

### DIFF
--- a/uidefinitions/createUiDefinition.json
+++ b/uidefinitions/createUiDefinition.json
@@ -223,13 +223,13 @@
                 "name": "filertype",
                 "type": "Microsoft.Common.DropDown",
                 "label": "File-system Type",
-                "defaultValue": "NFS",
+                "defaultValue": "[if(equals(steps('filesystem').shared.newexisting,'new'),'Builtin NFS','External NFS')]",
                 "toolTip": "Filer type for the /shared directory.",
                 "multiselect": false,
                 "constraints": {
                   "allowedValues": [
                     {
-                      "label": "NFS",
+                      "label": "[if(equals(steps('filesystem').shared.newexisting,'new'),'Builtin NFS','External NFS')]",
                       "value": "nfs"
                     },
                     {


### PR DESCRIPTION
UI File-systems tab: 
-Filer options changed to "NFS on Scheduler VM" if user selects "Create New" in either filer section
-Removed filer option for anything NFS-related when user selects "Use existing" in either filer section