### PR TITLE
Added support for ANF and external NFS

### DIFF
--- a/bicep/anf.bicep
+++ b/bicep/anf.bicep
@@ -2,13 +2,13 @@ targetScope = 'resourceGroup'
 
 param name string
 param location string
-param resourcePostfix string = uniqueString(resourceGroup().id,deployment().name)
+param resourcePostfix string = uniqueString(resourceGroup().id)
 param subnetId string
 param serviceLevel string
 param sizeGB int
 
 resource anfAccount 'Microsoft.NetApp/netAppAccounts@2022-05-01' = {
-  name: '${name}-account-${resourcePostfix}'
+  name: 'hpcanfaccount-${take(resourcePostfix,10)}'
   location: location
 }
 
@@ -22,12 +22,12 @@ resource anfPool 'Microsoft.NetApp/netAppAccounts/capacityPools@2022-05-01' = {
   }
 }
 
-resource anfHome 'Microsoft.NetApp/netAppAccounts/capacityPools/volumes@2022-05-01' = {
-  name: '${name}-anf-home'
+resource anfVolume 'Microsoft.NetApp/netAppAccounts/capacityPools/volumes@2022-05-01' = {
+  name: '${name}-anf-volume'
   location: location
   parent: anfPool
   properties: {
-    creationToken: 'home-${name}'
+    creationToken: '${name}-path'
     serviceLevel: serviceLevel
     networkFeatures: 'Standard'
     subnetId: subnetId
@@ -61,7 +61,7 @@ resource anfHome 'Microsoft.NetApp/netAppAccounts/capacityPools/volumes@2022-05-
 
 output anf_account_name string = anfAccount.name
 output anf_pool_name string = anfPool.name
-output anf_volume_name string = anfHome.name
-output nfs_home_ip string = anfHome.properties.mountTargets[0].ipAddress
-output nfs_home_path string = 'home-${resourcePostfix}'
-output nfs_home_opts string = 'rw,hard,rsize=262144,wsize=262144,vers=3,tcp,_netdev'
+output anf_volume_name string = anfVolume.name
+output anf_ip string = anfVolume.properties.mountTargets[0].ipAddress
+output anf_export_path string = '/${name}-path'
+output anf_opts string = 'rw,hard,rsize=262144,wsize=262144,vers=3,tcp,_netdev'

--- a/bicep/files-to-load/create_cc_param.py
+++ b/bicep/files-to-load/create_cc_param.py
@@ -51,29 +51,25 @@ def set_params(params,outputs):
     params['loginMachineType'] = (outputs['ccswConfig']['value']['slurm_settings']['login_nodes']['loginVMSize']).strip()
     params['NumberLoginNodes'] = int(outputs['ccswConfig']['value']['slurm_settings']['login_nodes']['initialNodes'])
     
-    #NFS
-    params['NFSType'] = outputs['ccswConfig']['value']['filesystem']['shared']['config']['filertype']
-    #FIX below: only works for NFS
-    params['FilesystemSize'] = outputs['ccswConfig']['value']['filesystem']['shared']['config']['nfs_capacity_in_gb']
-    params['UseBuiltinShared'] = True 
-    # if params['NFSType'] == 'nfs':
-    #     params['NFSAddress'] = outputs['ccswGlobalConfig']['value']['nfs_home_netad']
-    #     params['NFSSharedExportPath'] = outputs['ccswGlobalConfig']['value']['nfs_home_path']
-    #     params['NFSSharedMountOptions'] = outputs['ccswGlobalConfig']['value']['nfs_home_opts']
-    
-    #params['NFSAddress']
-    #params['NFSSharedMountOptions']
-    #params['NFSSharedExportPath']
+    #Network Attached Storage
+    params['UseBuiltinShared'] = outputs['filer_info_final']['value']['home']['create_new'] and (outputs['filer_info_final']['value']['home']['filertype'] == 'nfs')
+    if params['UseBuiltinShared']:
+        params['FilesystemSize'] = outputs['filer_info_final']['value']['home']['nfs_capacity_in_gb']
+    else:
+        params['NFSType'] = 'nfs' if outputs['filer_info_final']['value']['home']['filertype'] in ['nfs','anf'] else 'lustre'
+        if params['NFSType'] == 'nfs':
+            params['NFSSharedExportPath'] = outputs['filer_info_final']['value']['home']['export_path']
+            params['NFSSharedMountOptions'] = outputs['filer_info_final']['value']['home']['mount_options']
+        params['NFSAddress'] = outputs['filer_info_final']['value']['home']['ip_address']
 
-    #params['AdditionalNFS']
-    #params['NFSSchedType']
-    #params['NFSSchedAddress']
-    #params['NFSSchedMountOptions']
-    #params['NFSSchedExportPath']
-    #params['AdditionalNFSType']
-    #params['AdditionalNFSExportPath']
-    #params['AdditionalNFSMountOptions']
-    #params['AdditionalNFSMountPoint']
+    params['AdditionalNFS'] = outputs['filer_info_final']['value']['additional']['use']
+    if params['AdditionalNFS']:
+        params['AdditionalNFSType'] = 'nfs' if outputs['filer_info_final']['value']['additional']['filertype'] in ['nfs','anf'] else 'lustre'
+        if params['AdditionalNFSType'] == 'nfs':
+            params['AdditionalNFSMountPoint'] = outputs['filer_info_final']['value']['additional']['mount_path']
+            params['AdditionalNFSExportPath'] = outputs['filer_info_final']['value']['additional']['export_path']
+            params['AdditionalNFSMountOptions'] = outputs['filer_info_final']['value']['additional']['mount_options']
+        params['AdditionalNFSAddress'] = outputs['filer_info_final']['value']['additional']['ip_address']
 
 def main():
     slurm_params = get_json_dict('initial_params.json')

--- a/uidefinitions/createUiDefinition.json
+++ b/uidefinitions/createUiDefinition.json
@@ -317,7 +317,7 @@
                   "regex": "^(100|10[0-1]\\d{3}|[1-9]\\d{2}|[1-9]\\d{3}|[1-9]\\d{4}|102400)$",
                   "validationMessage": "Please enter an integer between 100 and 102400"
                 },
-                "visible": "[equals(steps('filesystem').shared.filertype,'nfs')]"
+                "visible": "[and(equals(steps('filesystem').shared.newexisting,'new'),equals(steps('filesystem').shared.filertype,'nfs'))]"
               },
               {
                 "name": "amlInfoBox",
@@ -414,7 +414,7 @@
                 "defaultValue": "",
                 "toolTip": "Mount options for the primary filer",
                 "constraints": {
-                  "required": true,
+                  "required": false,
                   "regex": "^.+$",
                   "validationMessage": "Please enter a mount option."
                 },
@@ -484,7 +484,7 @@
                 "constraints": {
                   "allowedValues": [
                     {
-                      "label": "NFS",
+                      "label": "[if(equals(steps('filesystem').additional.newexisting,'existing'),'NFS','')]",
                       "value": "nfs"
                     },
                     {
@@ -573,8 +573,8 @@
                   "regex": "^(100|10[0-1]\\d{3}|[1-9]\\d{2}|[1-9]\\d{3}|[1-9]\\d{4}|102400)$",
                   "validationMessage": "Please enter an integer between 100 and 102400"
                 },
-                "visible": "[equals(steps('filesystem').additional.filertype,'nfs')]"
-              },
+                "visible": "[and(equals(steps('filesystem').additional.newexisting,'new'),equals(steps('filesystem').additional.filertype,'nfs'))]"
+              }, 
               {
                 "name": "amlInfoBox",
                 "type": "Microsoft.Common.InfoBox",
@@ -683,7 +683,7 @@
                 "defaultValue": "",
                 "toolTip": "Mount options for the additional filer.",
                 "constraints": {
-                  "required": true,
+                  "required": false,
                   "regex": "^.+$",
                   "validationMessage": "Please enter a mount option."
                 },
@@ -1548,7 +1548,7 @@
               "lustre_tier": "[if(equals(steps('filesystem').shared.filertype,'aml'),steps('filesystem').shared.lustretier,'')]",
               "lustre_capacity_in_tib": "[if(equals(steps('filesystem').shared.filertype,'aml'),steps('filesystem').shared.azurelustrecapacity,-1)]",
               "ip_address": "[if(equals(steps('filesystem').shared.newexisting,'existing'),steps('filesystem').shared.ipAddress,'')]",
-              "export_path": "[steps('filesystem').shared.exportPath]",
+              "export_path": "[if(equals(steps('filesystem').shared.newexisting,'existing'),steps('filesystem').shared.exportPath,'')]",
               "mount_options": "[if(equals(steps('filesystem').shared.newexisting,'existing'),steps('filesystem').shared.mountOptions,'')]"
             }
           },
@@ -1556,15 +1556,15 @@
             "additional_filer": "[steps('filesystem').additionalCheck.checkbox]",
             "create_new": "[equals(steps('filesystem').additional.newexisting,'new')]",
             "config": {
-              "filertype": "[steps('filesystem').additional.filertype]",
+              "filertype": "[if(steps('filesystem').additionalCheck.checkbox,steps('filesystem').additional.filertype,'')]",
               "nfs_capacity_in_gb": "[if(equals(steps('filesystem').additional.filertype,'nfs'),steps('filesystem').additional.nfscapacity,-1)]",
               "anf_service_tier": "[if(equals(steps('filesystem').additional.filertype,'anf'),steps('filesystem').additional.anftier,'')]",
               "anf_capacity_in_bytes": "[if(equals(steps('filesystem').additional.filertype,'anf'),steps('filesystem').additional.anfcapacity,-1)]",
               "lustre_tier": "[if(equals(steps('filesystem').additional.filertype,'aml'),steps('filesystem').additional.lustretier,'')]",
               "lustre_capacity_in_tib": "[if(equals(steps('filesystem').additional.filertype,'aml'),steps('filesystem').additional.azurelustrecapacity,-1)]",
               "ip_address": "[if(equals(steps('filesystem').additional.newexisting,'existing'),steps('filesystem').additional.ipAddress,'')]",
-              "mount_path": "[steps('filesystem').additional.exportPath]",
-              "export_path": "[steps('filesystem').additional.exportPath]",
+              "mount_path": "[if(equals(steps('filesystem').additional.newexisting,'existing'),steps('filesystem').additional.mountPath,'')]",
+              "export_path": "[if(equals(steps('filesystem').additional.newexisting,'existing'),steps('filesystem').additional.exportPath,'')]",
               "mount_options": "[if(equals(steps('filesystem').additional.newexisting,'existing'),steps('filesystem').additional.mountOptions,'')]"
             }
           }


### PR DESCRIPTION
Added support for ANF and external NFS, laid groundwork for Lustre implementation

**Question** for @xpillons: in this implementation, I use the export paths and mount paths created by ANF when the user selects "Create New" for the additional file-system. If we keep this step, then should we remove those text boxes from the UI? I've kept them for now. 