### PR TITLE
restrict storage account access to cyclecloud and compute

### DIFF
--- a/bicep/ccsw.bicep
+++ b/bicep/ccsw.bicep
@@ -154,9 +154,9 @@ module ccswStorage './storage.bicep' = {
   params:{
     location: location
     saName: 'ccswstorage${uniqueString(resourceGroup().id)}'
-    lockDownNetwork: true // Restrict access to the storage account from compute and cyclecloud subnets, and lustre if used
+    lockDownNetwork: true // Restrict access to the storage account from compute and cyclecloud subnets
     allowableIps: []
-    subnetIds: concat([ subnets.compute.id],[subnets.cyclecloud.id], filer1_is_lustre || filer2_is_lustre ? [subnets.lustre.id] : [])
+    subnetIds: concat([subnets.compute.id], [subnets.cyclecloud.id])
   }
 }
 

--- a/bicep/ccsw.bicep
+++ b/bicep/ccsw.bicep
@@ -154,9 +154,9 @@ module ccswStorage './storage.bicep' = {
   params:{
     location: location
     saName: 'ccswstorage${uniqueString(resourceGroup().id)}'
-    lockDownNetwork: false
+    lockDownNetwork: true // Restrict access to the storage account from compute and cyclecloud subnets, and lustre if used
     allowableIps: []
-    subnetIds: concat([ subnets.compute.id],deploy_scheduler ? [subnets.scheduler.id] : [])
+    subnetIds: concat([ subnets.compute.id],[subnets.cyclecloud.id], filer1_is_lustre || filer2_is_lustre ? [subnets.lustre.id] : [])
   }
 }
 

--- a/bicep/storage.bicep
+++ b/bicep/storage.bicep
@@ -38,6 +38,8 @@ resource blobServices 'Microsoft.Storage/storageAccounts/blobServices@2022-09-01
   parent: storageAccount
 }
 
+// TODO: Need to remove as we can't attach a container to AMLFS in this version of the AMLFS RP
+// If so it has to be dependent on the AMLFS creation
 resource lustreArchive 'Microsoft.Storage/storageAccounts/blobServices/containers@2022-09-01' = {
   name: 'lustre'
   parent: blobServices


### PR DESCRIPTION
- restrict the storage account access to only the cyclecloud and compute subnets for security enforcement