### PR TITLE
Make entire additional config optional

### DIFF
--- a/bicep/ccsw.bicep
+++ b/bicep/ccsw.bicep
@@ -183,15 +183,15 @@ var filer_info = {
     create_new: ccswConfig.filesystem.shared.create_new
   }, ccswConfig.filesystem.shared.config)
   additional: union({
-    use: ccswConfig.filesystem.additional.additional_filer
-    create_new: ccswConfig.filesystem.additional.create_new
-  }, ccswConfig.filesystem.additional.config)
+    use: ccswConfig.filesystem.?additional.?additional_filer ?? false
+    create_new: ccswConfig.filesystem.?additional.?create_new ?? false
+  }, ccswConfig.filesystem.?additional.?config ?? {})
 }
 
 
 //TODO: Make Lustre work with filer_info object
 var filer1_is_lustre = ccswConfig.filesystem.shared.config.filertype == 'aml'
-var filer2_is_lustre = contains(ccswConfig.filesystem.additional.config, 'filertype') && ccswConfig.filesystem.additional.config.filertype == 'aml'
+var filer2_is_lustre = contains(ccswConfig.filesystem.?additional.?config ?? {}, 'filertype') && ccswConfig.filesystem.additional.config.filertype == 'aml'
 
 //only use first set of Lustre settings configured by the user 
 var lustre_info = concat(
@@ -210,8 +210,8 @@ var lustre_info = concat(
     union(
       {subnet_name: (createVnet ? 'hpc-lustre-subnet' : ccswConfig.network.vnet.subnets.filerSubnet2)},
       {config: {
-        sku: ccswConfig.filesystem.additional.config.lustre_tier
-        capacity: int(ccswConfig.filesystem.additional.config.lustre_capacity_in_tib)
+        sku: ccswConfig.filesystem.?additional.?config.?lustre_tier
+        capacity: int(ccswConfig.filesystem.?additional.?config.?lustre_capacity_in_tib ?? 0)
         filer: 'additional'
         }
       }
@@ -270,7 +270,7 @@ var fs_module_home = filer_info.home.create_new ? (filer_info.home.filertype == 
 
 // TODO: if we restore creation of additional FS, we can use the same concept. It will probably break for two amlfs deployments, but ...
 // that is incredibly expensive as well.
-var fs_module_additional = filer_info.additional.create_new ? (filer_info.additional.filertype == 'anf' ? ccswANF[0] : (filer_info.additional.filertype == 'aml' ? ccswAMLFS[0] : null)) : null
+var fs_module_additional = (filer_info.additional.?create_new ?? false) ? (filer_info.?additional.?filertype == 'anf' ? ccswANF[0] : (filer_info.?additional.?filertype == 'aml' ? ccswAMLFS[0] : null)) : null
 
 var filer_info_final = {
   home: {
@@ -286,13 +286,13 @@ var filer_info_final = {
 
   }
   additional: { 
-    use: ccswConfig.filesystem.additional.additional_filer
-    create_new: filer_info.additional.filertype
-    filertype: filer_info.additional.filertype
-    ip_address: fs_module_additional == null ? filer_info.additional.ip_address : fs_module_additional!.outputs.ip_address
-    export_path: fs_module_additional == null ? filer_info.additional.export_path : fs_module_additional!.outputs.export_path
-    mount_options: fs_module_additional == null ? filer_info.additional.mount_options : fs_module_additional!.outputs.mount_options
-    mount_path: filer_info.additional.mount_path
+    use: ccswConfig.filesystem.?additional.additional_filer ?? false
+    create_new: filer_info.?additional.?create_new ?? false
+    filertype: filer_info.?additional.?filertype
+    ip_address: fs_module_additional == null ? filer_info.?additional.?ip_address : fs_module_additional!.outputs.ip_address
+    export_path: fs_module_additional == null ? filer_info.?additional.?export_path : fs_module_additional!.outputs.export_path
+    mount_options: fs_module_additional == null ? filer_info.?additional.?mount_options : fs_module_additional!.outputs.mount_options
+    mount_path: filer_info.?additional.?mount_path
     }
 }
 output filer_info_final object = filer_info_final

--- a/bicep/network-new.bicep
+++ b/bicep/network-new.bicep
@@ -2,8 +2,8 @@ param address string = ccswConfig.network.vnet.address_space
 param location string
 param ccswConfig object
 
-param create_anf bool = ccswConfig.filesystem.shared.config.filertype == 'anf' || (contains(ccswConfig.filesystem.additional.config,'filertype') && ccswConfig.filesystem.additional.config.filertype == 'anf')
-param lustre_count int = (ccswConfig.filesystem.shared.config.filertype == 'aml' ? 1 : 0) + ((contains(ccswConfig.filesystem.additional.config,'filertype') && ccswConfig.filesystem.additional.config.filertype == 'aml') ? 1 : 0)
+param create_anf bool = ccswConfig.filesystem.shared.config.filertype == 'anf' || (contains(ccswConfig.filesystem.?additional.?config ?? {},'filertype') && ccswConfig.filesystem.additional.config.filertype == 'anf')
+param lustre_count int = (ccswConfig.filesystem.shared.config.filertype == 'aml' ? 1 : 0) + ((contains(ccswConfig.filesystem.?additional.?config ?? {},'filertype') && ccswConfig.filesystem.additional.config.filertype == 'aml') ? 1 : 0)
 param create_lustre bool = lustre_count > 0
 param deploy_bastion bool = ccswConfig.network.vnet.bastion
 param create_database bool = ccswConfig.slurm_settings.scheduler_node.slurmAccounting
@@ -413,7 +413,7 @@ resource subnetDatabase 'Microsoft.Network/virtualNetworks/subnets@2023-06-01' e
 var subnet_database = create_database ? rsc_output(subnetDatabase) : {}
 
 var filerType1 = ccswConfig.filesystem.shared.config.filertype
-var filerType2 = contains(ccswConfig.filesystem.additional.config, 'filertype') ? ccswConfig.filesystem.additional.config.filertype : 'none'
+var filerType2 = contains(ccswConfig.filesystem.?additional.?config ?? {}, 'filertype') ? ccswConfig.filesystem.additional.config.filertype : 'none'
 var need_filer1_subnet = filerType1 == 'aml' || filerType1 == 'anf'
 var need_filer2_subnet = filerType2 == 'aml' || (filerType2 == 'anf' && filerType1 != 'anf')
 var filer1 = need_filer1_subnet ? (filerType1 == 'anf' ? { anf: subnet_netapp } : { lustre: subnet_lustre }) : {}

--- a/uidefinitions/createUiDefinition.json
+++ b/uidefinitions/createUiDefinition.json
@@ -1487,9 +1487,9 @@
               "lustre_tier": "[if(equals(steps('filesystem').additional.filertype,'aml'),steps('filesystem').additional.lustretier,'')]",
               "lustre_capacity_in_tib": "[if(equals(steps('filesystem').additional.filertype,'aml'),steps('filesystem').additional.azurelustrecapacity,-1)]",
               "ip_address": "[if(equals(steps('filesystem').additional.newexisting,'existing'),steps('filesystem').additional.ipAddress,'')]",
-              "mount_path": "[steps('filesystem').additional.mountPath]",
+              "mount_path": "[if(steps('filesystem').additionalCheck.checkbox, steps('filesystem').additional.mountPath, '')]",
               "export_path": "[if(equals(steps('filesystem').additional.newexisting,'existing'),steps('filesystem').additional.exportPath,'')]",
-              "mount_options": "[steps('filesystem').additional.mountOptions]"
+              "mount_options": "[if(steps('filesystem').additionalCheck.checkbox, steps('filesystem').additional.mountOptions, '')]"
             }
           }
         },


### PR DESCRIPTION
We should not expect default values to always exist for additional filers - in fact, the entire section is optional when someone is creating a json param file themselves.