### PR TITLE
rename ANF parameters for consistency

### DIFF
--- a/bicep/anf.bicep
+++ b/bicep/anf.bicep
@@ -7,10 +7,10 @@ param tags tags_t
 param resourcePostfix string = uniqueString(resourceGroup().id)
 param subnetId string
 param serviceLevel string
-param sizeGB int
+param sizeTiB int
 param defaultMountOptions string
 param infrastructureOnly bool = false
-var capacity = sizeGB * 1024 * 1024 * 1024 * 1024
+var capacity = sizeTiB * 1024 * 1024 * 1024 * 1024
 
 resource anfAccount 'Microsoft.NetApp/netAppAccounts@2023-07-01' = if(!infrastructureOnly){
   name: 'hpcanfaccount-${take(resourcePostfix,10)}'

--- a/bicep/ccsw.bicep
+++ b/bicep/ccsw.bicep
@@ -210,7 +210,7 @@ module ccswANF 'anf.bicep' = [
       name: filer.key
       subnetId: subnets[filer.key].id
       serviceLevel: filer.value.anfServiceTier
-      sizeGB: int(filer.value.anfCapacityInBytes)
+      sizeTiB: int(filer.value.anfCapacityInTiB)
       defaultMountOptions: anfDefaultMountOptions
       infrastructureOnly: infrastructureOnly
     }

--- a/bicep/types.bicep
+++ b/bicep/types.bicep
@@ -13,7 +13,7 @@ type shared_nfs_existing_t = {
 type shared_anf_new_t = {
   type: 'anf-new'
   anfServiceTier: string
-  anfCapacityInBytes: int
+  anfCapacityInTiB: int
 }
 
 @discriminator('type')
@@ -23,7 +23,7 @@ type sharedFilesystem_t = shared_nfs_new_t | shared_nfs_existing_t | shared_anf_
 type additional_anf_new_t = {
   type: 'anf-new'
   anfServiceTier: string
-  anfCapacityInBytes: int
+  anfCapacityInTiB: int
   mountPath: string
   exportPath: string
 }

--- a/uidefinitions/createUiDefinition.json
+++ b/uidefinitions/createUiDefinition.json
@@ -1316,7 +1316,7 @@
         "type": "[concat(if(equals(steps('filesystem').shared.newexisting,'new'),steps('filesystem').shared.filertype,'nfs'),'-',steps('filesystem').shared.newexisting)]",
         "nfsCapacityInGb": "[if(equals(steps('filesystem').shared.filertype,'nfs'),steps('filesystem').shared.nfscapacity,basics('nullValue'))]",
         "anfServiceTier": "[if(equals(steps('filesystem').shared.filertype,'anf'),steps('filesystem').shared.anftier,basics('nullValue'))]",
-        "anfCapacityInBytes": "[if(equals(steps('filesystem').shared.filertype,'anf'),steps('filesystem').shared.anfcapacity,basics('nullValue'))]",
+        "anfCapacityInTiB": "[if(equals(steps('filesystem').shared.filertype,'anf'),steps('filesystem').shared.anfcapacity,basics('nullValue'))]",
         "ipAddress": "[if(equals(steps('filesystem').shared.newexisting,'existing'),steps('filesystem').shared.ipAddress,basics('nullValue'))]",
         "exportPath": "[if(equals(steps('filesystem').shared.newexisting,'existing'),steps('filesystem').shared.exportPath,basics('nullValue'))]",
         "mountOptions": "[if(equals(steps('filesystem').shared.newexisting,'existing'),steps('filesystem').shared.mountOptions,basics('nullValue'))]"
@@ -1324,7 +1324,7 @@
       "additionalFilesystem": {
         "type": "[if(steps('filesystem').additionalCheck.checkbox,concat(steps('filesystem').additional.filertype,'-',steps('filesystem').additional.newexisting),'disabled')]",
         "anfServiceTier": "[if(equals(steps('filesystem').additional.filertype,'anf'),steps('filesystem').additional.anftier,basics('nullValue'))]",
-        "anfCapacityInBytes": "[if(equals(steps('filesystem').additional.filertype,'anf'),steps('filesystem').additional.anfcapacity,basics('nullValue'))]",
+        "anfCapacityInTiB": "[if(equals(steps('filesystem').additional.filertype,'anf'),steps('filesystem').additional.anfcapacity,basics('nullValue'))]",
         "lustreTier": "[if(equals(steps('filesystem').additional.filertype,'aml'),steps('filesystem').additional.lustretier,basics('nullValue'))]",
         "lustreCapacityInTib": "[if(equals(steps('filesystem').additional.filertype,'aml'),steps('filesystem').additional.azurelustrecapacity,basics('nullValue'))]",
         "ipAddress": "[if(equals(steps('filesystem').additional.newexisting,'existing'),steps('filesystem').additional.ipAddress,basics('nullValue'))]",


### PR DESCRIPTION
All ANF values should be expressed in TiB

- rename sizeGB to sizeTiB
- rename anfCapacityInBytes to anfCapacityInTiB