### PR TITLE
don't create NVMe if mounted, changed md128 to md12

### DIFF
--- a/specs/default/cluster-init/scripts/08-nvme.sh
+++ b/specs/default/cluster-init/scripts/08-nvme.sh
@@ -3,6 +3,10 @@ script_dir="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 source "$script_dir/../files/common.sh" 
 
 function setup_nvme_disks() {
+
+    # If /mnt/nvme is already mounted then return
+    grep -qs '/mnt/nvme ' /proc/mounts && return
+
     NVME_DISKS_NAME=`ls /dev/nvme*n1`
     NVME_DISKS=`ls -latr /dev/nvme*n1 | wc -l`
 
@@ -15,9 +19,9 @@ function setup_nvme_disks() {
         mkdir -p /mnt/nvme
         # Needed incase something did not unmount as expected. This will delete any data that may be left behind
         mdadm  --stop /dev/md*
-        mdadm --create /dev/md128 -f --run --level 0 --raid-devices $NVME_DISKS $NVME_DISKS_NAME
-        mkfs.xfs -f /dev/md128
-        mount /dev/md128 /mnt/nvme || exit 1
+        mdadm --create /dev/md12 -f --run --level 0 --name nvme --raid-devices $NVME_DISKS $NVME_DISKS_NAME
+        mkfs.xfs -f /dev/md12
+        mount /dev/md12 /mnt/nvme || exit 1
     fi
 
     chmod 1777 /mnt/nvme


### PR DESCRIPTION
On AlmaLinux 8.10, using md128 generates an error because you have to use values below 128. Updated md128 to md12

Adding a test to avoid mounting again if already mounted