### PR TITLE
Update Alma version in slurm template, Readme and initial slurm version

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,7 +94,7 @@ Before using an existing virtual network, check for the pre-requisites in [Bring
 Specify the VM size and image to use for the Scheduler and the Login nodes. Images are the HPC Images provided in the Azure Marketplace with the associated URIs:
 | Image Name | URI |
 |------------|-----|
-| Alma Linux 8.7 | almalinux:almalinux-hpc:8_7-hpc-gen2:latest |
+| Alma Linux 8.10 | almalinux:almalinux-hpc:8_10-hpc-gen2:latest |
 | Ubuntu 20.04 | microsoft-dsvm:ubuntu-hpc:2004:latest |
 | Ubuntu 22.04 | microsoft-dsvm:ubuntu-hpc:2204:latest |
 

--- a/bicep/files-to-load/initial_params.json
+++ b/bicep/files-to-load/initial_params.json
@@ -23,7 +23,7 @@
     "configuration_slurm_ha_enabled": false,
     "configuration_slurm_launch_parameters": null,
     "configuration_slurm_shutdown_policy": "Terminate",
-    "configuration_slurm_version": "23.11.7-1",
+    "configuration_slurm_version": "23.11.10-2",
     "Credentials": "azure",
     "DynamicClusterInitSpecs": null,
     "DynamicImageName": "almalinux8",

--- a/bicep/files-to-load/slurm-workspace.txt
+++ b/bicep/files-to-load/slurm-workspace.txt
@@ -703,8 +703,8 @@ Order = 20
         ParameterType = StringList
         Config.Plugin = pico.form.Dropdown
         Config.FreeForm = true
-        Config.Entries := {[Value="23.02.7-4"], [Value="23.11.7-1"]}
-        DefaultValue = 23.11.7-1
+        Config.Entries := {[Value="24.05.4-2"], [Value="23.11.10-2"]}
+        DefaultValue = 24.05.4-2
 
         [[[parameter configuration_slurm_accounting_enabled]]]
         Label = Job Accounting
@@ -814,42 +814,42 @@ Order = 20
         ParameterType = Cloud.Image
         Config.OS = linux
         DefaultValue = almalinux8
-        Config.Filter := Package in {"cycle.image.centos7", "cycle.image.ubuntu20", "cycle.image.ubuntu22", "cycle.image.sles15-hpc", "almalinux8"}
+        Config.Filter := Package in {"cycle.image.ubuntu20", "cycle.image.ubuntu22", "cycle.image.sles15-hpc", "almalinux8"}
 
         [[[parameter LoginImageName]]]
         Label = Login Node OS
         ParameterType = Cloud.Image
         Config.OS = linux
         DefaultValue = almalinux8
-        Config.Filter := Package in {"cycle.image.centos7", "cycle.image.ubuntu20", "cycle.image.ubuntu22", "cycle.image.sles15-hpc", "almalinux8"}
+        Config.Filter := Package in {"cycle.image.ubuntu20", "cycle.image.ubuntu22", "cycle.image.sles15-hpc", "almalinux8"}
 
         [[[parameter HPCImageName]]]
         Label = HPC OS
         ParameterType = Cloud.Image
         Config.OS = linux
         DefaultValue = almalinux8
-        Config.Filter := Package in {"cycle.image.centos7", "cycle.image.ubuntu20", "cycle.image.ubuntu22", "cycle.image.sles15-hpc", "almalinux8"}
+        Config.Filter := Package in {"cycle.image.ubuntu20", "cycle.image.ubuntu22", "cycle.image.sles15-hpc", "almalinux8"}
 
         [[[parameter HTCImageName]]]
         Label = HTC OS
         ParameterType = Cloud.Image
         Config.OS = linux
         DefaultValue = almalinux8
-        Config.Filter := Package in {"cycle.image.centos7", "cycle.image.ubuntu20", "cycle.image.ubuntu22", "cycle.image.sles15-hpc", "almalinux8"}
+        Config.Filter := Package in {"cycle.image.ubuntu20", "cycle.image.ubuntu22", "cycle.image.sles15-hpc", "almalinux8"}
 
         [[[parameter GPUImageName]]]
         Label = GPU OS
         ParameterType = Cloud.Image
         Config.OS = linux
         DefaultValue = almalinux8
-        Config.Filter := Package in {"cycle.image.centos7", "cycle.image.ubuntu20", "cycle.image.ubuntu22", "cycle.image.sles15-hpc", "almalinux8"}
+        Config.Filter := Package in {"cycle.image.ubuntu20", "cycle.image.ubuntu22", "cycle.image.sles15-hpc", "almalinux8"}
 
         [[[parameter DynamicImageName]]]
         Label = Dynamic OS
         ParameterType = Cloud.Image
         Config.OS = linux
         DefaultValue = almalinux8
-        Config.Filter := Package in {"cycle.image.centos7", "cycle.image.ubuntu20", "cycle.image.ubuntu22", "cycle.image.sles15-hpc", "almalinux8"}
+        Config.Filter := Package in {"cycle.image.ubuntu20", "cycle.image.ubuntu22", "cycle.image.sles15-hpc", "almalinux8"}
 
         [[[parameter SchedulerClusterInitSpecs]]]
         Label = Scheduler Cluster-Init


### PR DESCRIPTION
This PR is updates the following:

-  slurm version options in the shipped template
-  Alma 8.7 was referenced in the Readme, update to 8.10
-  Update the slurm_version in the inital parameter file.