### PR TITLE
make sched disk persistent

### DIFF
--- a/bicep/files-to-load/slurm-workspace.txt
+++ b/bicep/files-to-load/slurm-workspace.txt
@@ -128,7 +128,7 @@ Autoscale = $Autoscale
         Size = $SchedFilesystemSize
         SSD = True
         Mount = builtinsched
-        Persistent = False
+        Persistent = True
         Disabled = ${!UseBuiltinSched || configuration_slurm_ha_enabled}
 
         [[[volume shared]]]


### PR DESCRIPTION
now that Slurm state is stored on /sched, this disk needs to be persistent.