### PR TITLE
EntraID Application with Federated Credentials

### DIFF
--- a/bicep/bicepconfig.json
+++ b/bicep/bicepconfig.json
@@ -1,0 +1,9 @@
+{
+    "experimentalFeaturesEnabled": {
+        "extensibility": true
+    },
+    // specify an alias for the version of the v1.0 dynamic types package you want to use
+    "extensions": {
+      "microsoftGraphV1": "br:mcr.microsoft.com/bicep/extensions/microsoftgraph/v1.0:0.1.8-preview"
+    }
+}

--- a/bicep/ccw.bicep
+++ b/bicep/ccw.bicep
@@ -249,13 +249,22 @@ module ccwANF 'anf.bicep' = [
   }
 ]
 
+module oodNIC 'ood-NIC.bicep' = if (deployOOD) {
+  name: 'oodNIC'
+  params: {
+    location: location
+    name: 'ood-${uniqueString(az.resourceGroup().id)}'
+    networkInterfacesTags: getTags('Microsoft.Network/networkInterfaces', tags)
+    subnetId: subnets.compute.id
+  }
+}
+
 module oodApp 'oodEntraApp.bicep' = if (deployOOD) {
   name: 'oodApp'
   params: {
     location: location
-    appName: 'ood-entra-${uniqueString(az.resourceGroup().id)}'
-    miName: 'ood-mi-${uniqueString(az.resourceGroup().id)}'
-    redirectURI: 'https://ood-fqdn/oidc'
+    name: 'ood-${uniqueString(az.resourceGroup().id)}'
+    redirectURI: 'https://${oodNIC.outputs.privateIp}/oidc'
   }
 }
 

--- a/bicep/ccw.bicep
+++ b/bicep/ccw.bicep
@@ -31,6 +31,7 @@ param databaseConfig types.databaseConfig_t
 param clusterName string
 param manualInstall bool
 param acceptMarketplaceTerms bool
+param deployOOD bool
 
 var anfDefaultMountOptions = 'rw,hard,rsize=262144,wsize=262144,vers=3,tcp,_netdev'
 
@@ -248,14 +249,13 @@ module ccwANF 'anf.bicep' = [
   }
 ]
 
-var deployOOD = false
 module oodApp 'oodEntraApp.bicep' = if (deployOOD) {
   name: 'oodApp'
   params: {
     location: location
     appName: 'ood-entra-${uniqueString(az.resourceGroup().id)}'
     miName: 'ood-mi-${uniqueString(az.resourceGroup().id)}'
-    fqdn: ''
+    redirectURI: 'https://ood-fqdn/oidc'
   }
 }
 

--- a/bicep/ccw.bicep
+++ b/bicep/ccw.bicep
@@ -255,7 +255,7 @@ module oodApp 'oodEntraApp.bicep' = if (deployOOD) {
     location: location
     appName: 'ood-entra-${uniqueString(az.resourceGroup().id)}'
     miName: 'ood-mi-${uniqueString(az.resourceGroup().id)}'
-    oodIPorName: ''
+    fqdn: ''
   }
 }
 

--- a/bicep/ccw.bicep
+++ b/bicep/ccw.bicep
@@ -248,6 +248,17 @@ module ccwANF 'anf.bicep' = [
   }
 ]
 
+var deployOOD = false
+module oodApp 'oodEntraApp.bicep' = if (deployOOD) {
+  name: 'oodApp'
+  params: {
+    location: location
+    appName: 'ood-entra-${uniqueString(az.resourceGroup().id)}'
+    miName: 'ood-mi-${uniqueString(az.resourceGroup().id)}'
+    oodIPorName: ''
+  }
+}
+
 output filerInfoFinal types.filerInfo_t = {
   home: {
     type: sharedFilesystem.type

--- a/bicep/mainTemplate.bicep
+++ b/bicep/mainTemplate.bicep
@@ -26,7 +26,7 @@ param databaseConfig types.databaseConfig_t = { type: 'disabled' }
 @description('The user-defined name of the cluster. Regex: ^[a-zA-Z0-9@_-]{3,}$')
 param clusterName string = 'ccw'
 param acceptMarketplaceTerms bool = false
-
+param deployOOD bool = false
 param infrastructureOnly bool = false
 param insidersBuild bool = false
 
@@ -73,5 +73,6 @@ module makeCCWresources 'ccw.bicep' = {
     projectVersion: projectVersion
     manualInstall: manualInstall
     acceptMarketplaceTerms: acceptMarketplaceTerms
+    deployOOD : deployOOD
   }
 }

--- a/bicep/ood-NIC.bicep
+++ b/bicep/ood-NIC.bicep
@@ -1,0 +1,28 @@
+targetScope = 'resourceGroup'
+import * as types from './types.bicep'
+
+param name string
+param location string
+param networkInterfacesTags types.tags_t
+param subnetId string
+
+resource nic 'Microsoft.Network/networkInterfaces@2023-11-01' = {
+  name: '${name}-nic'
+  location: location
+  tags: networkInterfacesTags
+  properties: {
+    ipConfigurations: [
+      {
+        name: '${name}-ipconfig'
+        properties: {
+            subnet: {
+              id: subnetId
+            }
+            privateIPAllocationMethod: 'Dynamic'
+          }
+      }
+    ]
+  }
+}
+
+output privateIp string = nic.properties.ipConfigurations[0].properties.privateIPAddress

--- a/bicep/oodEntraApp.bicep
+++ b/bicep/oodEntraApp.bicep
@@ -7,7 +7,7 @@ param location string
 
 param miName string
 param appName string
-param oodIPorName string = 'ood-vm-ip-or-name' // Open OnDemand VM IP or DNS name, default value as a placeholder so this can be manually updated in the azure portal
+param fqdn string = 'ood-fqdn' // Open OnDemand VM FQDN or IP, default value as a placeholder so this can be manually updated in the azure portal
 
 
 // NOTE: Microsoft Graph Bicep file deployment is only supported in Public Cloud
@@ -73,7 +73,7 @@ resource oodApp 'Microsoft.Graph/applications@v1.0' = {
     redirectUriSettings: [
       {
         index: 0
-        uri: 'https://${oodIPorName}/oidc'
+        uri: 'https://${fqdn}/oidc'
       }
     ]
   }

--- a/bicep/oodEntraApp.bicep
+++ b/bicep/oodEntraApp.bicep
@@ -7,8 +7,7 @@ param location string
 
 param miName string
 param appName string
-param fqdn string = 'ood-fqdn' // Open OnDemand VM FQDN or IP, default value as a placeholder so this can be manually updated in the azure portal
-
+param redirectURI string = 'https://ood-fqdn/oidc' // Redirect URI for OIDC
 
 // NOTE: Microsoft Graph Bicep file deployment is only supported in Public Cloud
 var audiences = {
@@ -73,7 +72,7 @@ resource oodApp 'Microsoft.Graph/applications@v1.0' = {
     redirectUriSettings: [
       {
         index: 0
-        uri: 'https://${fqdn}/oidc'
+        uri: redirectURI
       }
     ]
   }

--- a/bicep/oodEntraApp.bicep
+++ b/bicep/oodEntraApp.bicep
@@ -5,8 +5,7 @@ param location string
 // Creates a secret-less client application, using a user-assigned managed identity
 // as the credential (configured as part of the application's federated identity credential).
 
-param miName string
-param appName string
+param name string
 param redirectURI string = 'https://ood-fqdn/oidc' // Redirect URI for OIDC
 
 // NOTE: Microsoft Graph Bicep file deployment is only supported in Public Cloud
@@ -43,7 +42,7 @@ resource msGraphSP 'Microsoft.Graph/servicePrincipals@v1.0' existing = {
 var graphScopes = msGraphSP.oauth2PermissionScopes
 // create a user assigned managed identity to be assigned to the OOD VM
 resource oodManagedIdentity 'Microsoft.ManagedIdentity/userAssignedIdentities@2023-01-31' = {
-  name: miName
+  name: '${name}-mi'
   location: location
 }
 
@@ -51,8 +50,8 @@ resource oodManagedIdentity 'Microsoft.ManagedIdentity/userAssignedIdentities@20
 // The FIC is configured with the managed identity as the subject
 // The application is listed under the "App registrations" in the Azure Portal
 resource oodApp 'Microsoft.Graph/applications@v1.0' = {
-  displayName: appName
-  uniqueName: guid(subscription().id, resourceGroup().id, appName) // Need to be unique inside the tenant
+  displayName: '${name}-app'
+  uniqueName: guid(subscription().id, resourceGroup().id, name) // Need to be unique inside the tenant, issue is if you manually delete the app, it will failed if you recreate it with the same name
 
   resource myMsiFic 'federatedIdentityCredentials@v1.0' = {
     name: '${oodApp.uniqueName}/msiAsFic'

--- a/bicep/oodEntraApp.bicep
+++ b/bicep/oodEntraApp.bicep
@@ -1,0 +1,107 @@
+extension microsoftGraphV1
+targetScope = 'resourceGroup'
+param location string
+
+// Creates a secret-less client application, using a user-assigned managed identity
+// as the credential (configured as part of the application's federated identity credential).
+
+param miName string
+param appName string
+param oodIPorName string = 'ood-vm-ip-or-name' // Open OnDemand VM IP or DNS name, default value as a placeholder so this can be manually updated in the azure portal
+
+
+// NOTE: Microsoft Graph Bicep file deployment is only supported in Public Cloud
+var audiences = {
+  AzureCloud: {
+    uri: 'api://AzureADTokenExchange'
+  }
+  AzureUSGovernment: {
+    uri: 'api://AzureADTokenExchangeUSGov'
+  }
+  USNat: {
+    uri: 'api://AzureADTokenExchangeUSNat'
+  }
+  USSec: {
+    uri: 'api://AzureADTokenExchangeUSSec'
+  }
+  AzureChinaCloud: {
+    uri: 'api://AzureADTokenExchangeChina'
+  }
+}
+
+var cloudEnvironment = environment().name
+// login endpoint and tenant ID and issuer
+var loginEndpoint = environment().authentication.loginEndpoint
+var tenantId = tenant().tenantId
+var issuer = '${loginEndpoint}${tenantId}/v2.0'
+var graphAppId = '00000003-0000-0000-c000-000000000000'
+var appScopes = ['profile','User.Read'] // this is required for OIDC auth
+
+// Find Graph based on well-known appId
+resource msGraphSP 'Microsoft.Graph/servicePrincipals@v1.0' existing = {
+  appId: graphAppId
+}
+var graphScopes = msGraphSP.oauth2PermissionScopes
+// create a user assigned managed identity to be assigned to the OOD VM
+resource oodManagedIdentity 'Microsoft.ManagedIdentity/userAssignedIdentities@2023-01-31' = {
+  name: miName
+  location: location
+}
+
+// Create a (client) application registration with a federated identity credential (FIC)
+// The FIC is configured with the managed identity as the subject
+// The application is listed under the "App registrations" in the Azure Portal
+resource oodApp 'Microsoft.Graph/applications@v1.0' = {
+  displayName: appName
+  uniqueName: guid(subscription().id, resourceGroup().id, appName) // Need to be unique inside the tenant
+
+  resource myMsiFic 'federatedIdentityCredentials@v1.0' = {
+    name: '${oodApp.uniqueName}/msiAsFic'
+    description: 'Trust the Open OnDemand\'s user-assigned MI as a credential for the application'
+    audiences: [
+       audiences[cloudEnvironment].uri
+    ]
+    issuer: issuer
+    subject: oodManagedIdentity.properties.principalId
+  }
+
+  web: {
+    implicitGrantSettings: {
+      enableAccessTokenIssuance: false
+      enableIdTokenIssuance: true
+    }
+    redirectUriSettings: [
+      {
+        index: 0
+        uri: 'https://${oodIPorName}/oidc'
+      }
+    ]
+  }
+
+  optionalClaims: {
+    idToken: [
+      {
+        additionalProperties: []
+        essential: false
+        name: 'upn'
+        source: null
+      }
+    ]
+  }
+
+  // This is to define API permissions under App registration -> API permission in the Azure Portal
+  requiredResourceAccess: [
+    {
+      resourceAppId: graphAppId
+      resourceAccess: [ for (scope,i) in appScopes: {
+          id: filter(graphScopes, graphScopes => graphScopes.value == scope)[0].id
+          type: 'Scope'
+        }
+      ]
+    }
+  ]
+}
+
+// outputs
+output oodClientAppId string = oodApp.appId
+output oodMiId string = oodManagedIdentity.id


### PR DESCRIPTION
To allow Open OnDemand authentication with EntraID without secrets.
- Create a User Managed Identity to be assigned to the OOD VM
- Create a NIC in the compute-subnet to be assigned to the OOD VM (required to know the private IP in advance)
- Register an EntraID application with Federated Credentials using the UMI. Set the Redirect URI on https://<ood_ip>/oidc

Known Issue :
- EntraApp needs a unique name, if you delete it and recreate it using the same input parameters, you will get an error saying the unique name is already used.