### PR TITLE
add nconnect to anf mount options

### DIFF
--- a/bicep/ccw.bicep
+++ b/bicep/ccw.bicep
@@ -32,7 +32,7 @@ param clusterName string
 param manualInstall bool
 param acceptMarketplaceTerms bool
 
-var anfDefaultMountOptions = 'rw,hard,rsize=262144,wsize=262144,vers=3,tcp,_netdev'
+var anfDefaultMountOptions = 'rw,hard,rsize=262144,wsize=262144,vers=3,tcp,_netdev,nconnect=8'
 
 func getTags(resource_type string, tags types.resource_tags_t) types.tags_t => tags[?resource_type] ?? {}
 


### PR DESCRIPTION
increase performance of ANF mount using recommended client mount option "nconnect=8"

[https://learn.microsoft.com/en-us/azure/azure-netapp-files/performance-linux-mount-options#nconnect](https://learn.microsoft.com/en-us/azure/azure-netapp-files/performance-linux-mount-options#nconnect)