### PR TITLE
Fix bicep-typeless.py to allow build script to work following MI changes

### DIFF
--- a/bicep-typeless.py
+++ b/bicep-typeless.py
@@ -44,6 +44,8 @@ def process_bicep(input_path: str, output_path: str) -> None:
             if line.startswith("param") or line.startswith("output"):
                 fw.write(process_param(line))
             elif line.startswith("import"):
+                if "exports.bicep" in line:
+                    fw.write(line)
                 continue
             elif line.startswith("func "):
                 fw.write(process_func(line))


### PR DESCRIPTION
bicep-typeless.py, which gets called in build.sh, initially removed all lines that contain the keyphrase "import" in them. This behavior caused the import of exports.bicep (which contains the role assignments dictionary) in the two role assignments files to not appear in the typeless bicep files that are ran by build.sh to generate the ARM template. 

This change rectifies this issue. 