### PR TITLE
Satisfy ARM-ttk by using uri() function in oodApp module call

### DIFF
--- a/bicep/ccw.bicep
+++ b/bicep/ccw.bicep
@@ -264,7 +264,7 @@ module oodApp 'oodEntraApp.bicep' = if (deployOOD) {
   params: {
     location: location
     name: 'ood-${uniqueString(az.resourceGroup().id)}'
-    redirectURI: 'https://${oodNIC.outputs.privateIp}/oidc'
+    redirectURI: uri('https://${oodNIC.outputs.privateIp}','/oidc')
   }
 }
 


### PR DESCRIPTION
CCWS fails to pass arm-ttk due to an error with how the redirectURI input of the oodApp module is constructed. The error is: 

> Function 'format' found within 'redirectURI' 

format() appears in the ARM template when string interpolation is used is bicep. 

The fix is to use the uri() function when passing along URIs constructed using functions (string interpolation or concat) as per [this thread](https://github.com/Azure/arm-ttk/issues/417).