### PR TITLE
utility to register an entra app for OOD

### DIFF
--- a/bicep/ccw.bicep
+++ b/bicep/ccw.bicep
@@ -259,12 +259,18 @@ module oodNIC 'ood-NIC.bicep' = if (deployOOD) {
   }
 }
 
+// create a user assigned managed identity to be assigned to the OOD VM
+resource oodNewManagedIdentity 'Microsoft.ManagedIdentity/userAssignedIdentities@2023-01-31' = if (deployOOD) {
+  name: 'ood-${uniqueString(az.resourceGroup().id)}-mi'
+  location: location
+}
+
 module oodApp 'oodEntraApp.bicep' = if (deployOOD) {
   name: 'oodApp'
   params: {
-    location: location
-    name: 'ood-${uniqueString(az.resourceGroup().id)}'
-    redirectURI: uri('https://${oodNIC.outputs.privateIp}','/oidc')
+    umiName: 'ood-${uniqueString(az.resourceGroup().id)}-mi'
+    appName: 'ood-${uniqueString(az.resourceGroup().id)}-app'
+    fqdn: oodNIC.outputs.privateIp
   }
 }
 

--- a/util/register_app/bicepconfig.json
+++ b/util/register_app/bicepconfig.json
@@ -1,0 +1,9 @@
+{
+    "experimentalFeaturesEnabled": {
+        "extensibility": true
+    },
+    // specify an alias for the version of the v1.0 dynamic types package you want to use
+    "extensions": {
+      "microsoftGraphV1": "br:mcr.microsoft.com/bicep/extensions/microsoftgraph/v1.0:0.1.8-preview"
+    }
+}

--- a/util/register_app/main.bicep
+++ b/util/register_app/main.bicep
@@ -1,0 +1,23 @@
+extension microsoftGraphV1
+targetScope = 'resourceGroup'
+
+@description('User Managed Identity Name for Open OnDemand')
+param miName string
+
+// Creates a secret-less client application, using a user-assigned managed identity
+// as the credential (configured as part of the application's federated identity credential).
+
+@description('EntraID Application Name')
+param name string
+@description('FQDN, public or private IP of the OOD VM')
+param fqdn string
+
+module oodApp '../../bicep/oodEntraApp.bicep' = {
+  name: 'oodApp'
+  params: {
+    umiName: miName
+    appName: name
+    fqdn: fqdn
+  }
+}
+

--- a/util/register_app/main.bicepparam
+++ b/util/register_app/main.bicepparam
@@ -1,0 +1,4 @@
+using './main.bicep'
+param miName = 'ood_mi'
+param name = 'ood_ccws_01211133_app2'
+param fqdn = 'foo'

--- a/util/register_app/main.bicepparam
+++ b/util/register_app/main.bicepparam
@@ -1,4 +1,4 @@
 using './main.bicep'
-param miName = 'ood_mi'
-param name = 'ood_ccws_01211133_app2'
+param miName = 'ccw_ood_shared_mi'
+param name = 'ccw_ood_shared_app'
 param fqdn = 'foo'


### PR DESCRIPTION
- separate the Entra App registration needed for OIDC with OOD from the main deployment.
- move the creation of the UMI of OOD outside of the oodEntraApp.bicep file
- added a new util/register_app/ folder with files needed to register an app
