### PR TITLE
deny public Blob access by default

### DIFF
--- a/bicep/storage.bicep
+++ b/bicep/storage.bicep
@@ -25,6 +25,7 @@ resource storageAccount 'Microsoft.Storage/storageAccounts@2024-01-01' = {
     minimumTlsVersion: 'TLS1_2'
     allowSharedKeyAccess: false
     publicNetworkAccess: 'Disabled'
+    allowBlobPublicAccess: false
     networkAcls: {
       defaultAction: 'Deny'
       }      


### PR DESCRIPTION
default is true, event if we deny public network access. This can break policies which test the public access