### PR TITLE
Fixed quoting issue with deployment

### DIFF
--- a/bicep/install.sh
+++ b/bicep/install.sh
@@ -249,7 +249,7 @@ cycle_server start --wait
 # this will block until CC responds
 curl -k https://localhost
 
-cyclecloud initialize --batch --url=https://localhost --username=${CYCLECLOUD_USERNAME} --password=${CYCLECLOUD_PASSWORD} --verify-ssl=false --name=$SLURM_CLUSTER_NAME
+cyclecloud initialize --batch --url=https://localhost --username=${CYCLECLOUD_USERNAME} --password="${CYCLECLOUD_PASSWORD}" --verify-ssl=false --name=$SLURM_CLUSTER_NAME
 echo "CC CLI initialize successful"
 
 # Ensure CC properly initializes

--- a/bicep/vm.bicep
+++ b/bicep/vm.bicep
@@ -123,9 +123,8 @@ resource cse 'Microsoft.Compute/virtualMachines/extensions@2024-03-01' = {
     type: 'CustomScript'
     typeHandlerVersion: '2.0'
     protectedSettings: {
-      commandToExecute: 'jq -n --arg adminPassword "${adminPassword}" --arg databaseAdminPassword "${databaseAdminPassword}" \'{adminPassword: $adminPassword, databaseAdminPassword: $databaseAdminPassword}\' > /root/ccw.secrets.json'
+      commandToExecute: 'jq -n --arg adminPassword \'${adminPassword}\' --arg databaseAdminPassword \'${databaseAdminPassword}\' \'{adminPassword: $adminPassword, databaseAdminPassword: $databaseAdminPassword}\' > /root/ccw.secrets.json'
     }
-    
   }
 }
 


### PR DESCRIPTION
Fixed two issues:
* The bicep file was running jq and quoting the passwords with double quotes.  This is evaluated with bash and special characters can cause issues, e.g. myPassword$123.  This has been updated to single quotes instead.
* The install script does not quote the password - this would fail if it contained a space.