### PR TITLE
fix: remove fqdns from getent hosts in rename_hosts scripts

### DIFF
--- a/specs/default/cluster-init/files/almalinux/rename_host.sh
+++ b/specs/default/cluster-init/files/almalinux/rename_host.sh
@@ -10,7 +10,7 @@ function enforce_hostname() {
     hostname $target_hostname
   fi
   logger -s "Check in /etc/hosts"
-  hostname_in_hosts=$(getent hosts $(ifconfig eth0 | grep "inet " | xargs) | xargs | cut -d ' ' -f2 | tr '[:upper:]' '[:lower:]')
+  hostname_in_hosts=$(getent hosts $(ifconfig eth0 | grep "inet " | xargs) | xargs | cut -d ' ' -f2 | tr '[:upper:]' '[:lower:]') | cut -d'.' -f1
   if [ "$hostname_in_hosts" != "$target_hostname" ]; then
     logger -s "Warning: incorrect hostname ($hostname_in_hosts) in /etc/hosts, updating"
     sed -i "s/$hostname_in_hosts/$target_hostname/ig" /etc/hosts

--- a/specs/default/cluster-init/files/ubuntu/rename_host.sh
+++ b/specs/default/cluster-init/files/ubuntu/rename_host.sh
@@ -10,7 +10,7 @@ function enforce_hostname() {
     hostname $target_hostname
   fi
   logger -s "Check in /etc/hosts"
-  hostname_in_hosts=$(getent hosts $(ifconfig eth0 | grep "inet " | xargs) | xargs | cut -d ' ' -f2 | tr '[:upper:]' '[:lower:]')
+  hostname_in_hosts=$(getent hosts $(ifconfig eth0 | grep "inet " | xargs) | xargs | cut -d ' ' -f2 | tr '[:upper:]' '[:lower:]') | cut -d'.' -f1
   if [ "$hostname_in_hosts" != "$target_hostname" ]; then
     logger -s "Warning: incorrect hostname ($hostname_in_hosts) in /etc/hosts, updating"
     sed -i "s/$hostname_in_hosts/$target_hostname/ig" /etc/hosts

--- a/specs/default/cluster-init/scripts/01-rename_host.sh
+++ b/specs/default/cluster-init/scripts/01-rename_host.sh
@@ -20,7 +20,7 @@ function check_host_renaming() {
       # Get current hostname
       current_hostname=$(hostname | tr '[:upper:]' '[:lower:]')
       # Get hostname associated with the IP address
-      hostname_in_hosts=$(getent hosts $(ifconfig eth0 | grep "inet " | xargs) | xargs | cut -d ' ' -f2 | tr '[:upper:]' '[:lower:]')
+      hostname_in_hosts=$(getent hosts $(ifconfig eth0 | grep "inet " | xargs) | xargs | cut -d ' ' -f2 | tr '[:upper:]' '[:lower:]') | cut -d'.' -f1
       logger -s "Current hostname: $current_hostname"
       logger -s "Hostname returned by 'getent hosts': $hostname_in_hosts"
       logger -s "Target hostname: $target_hostname"


### PR DESCRIPTION
In certain situations, our rename-hosts logic fails because suffixes are not properly stripped from the hostname. This PR fixes that issue.