### PR TITLE
update yum repo to use https for azure.repo.almalinux.org

### DIFF
--- a/bicep/install.sh
+++ b/bicep/install.sh
@@ -76,9 +76,12 @@ if command -v apt; then
     retry_command "apt update -y"
     #apt install -y 
 else
+    # update the almalinux repo to use HTTPS inteads of the default HTTP for azure.repo.almalinux.org
+    sed -i 's|# baseurl=https://repo.almalinux.org/almalinux|baseurl=https://azure.repo.almalinux.org/|' /etc/yum.repos.d/almalinux.repo
+    dnf clean all
+    dnf makecache
     retry_command "yum update -y --exclude=cyclecloud*" 5 60
     retry_command "yum install -y jq"
-
 fi
 
 printf "\n\n"


### PR DESCRIPTION
the base image is configured to use HTTP when accesing repo azure.repo.almalinux.org which can be denied by some security rules.
This fix set the baseurl for repos baseos, appstream and extras to be https://azure.repo.almalinux.org

Please be aware that these lines would have to be added in the cloud-init section of compute nodes using azure alma linux image
```bash
#!/bin/bash
sed -i 's|# baseurl=https://repo.almalinux.org/almalinux|baseurl=https://azure.repo.almalinux.org/|' /etc/yum.repos.d/*.repo
dnf clean all
dnf makecache
```