### PR TITLE
Update API versions and minimise unhelpful warnings in build script

### DIFF
--- a/bicep/amlfs.bicep
+++ b/bicep/amlfs.bicep
@@ -23,7 +23,7 @@ param capacity int
 param infrastructureOnly bool = false
 param availabilityZone availabilityZone_t[]
 
-resource fileSystem 'Microsoft.StorageCache/amlFileSystems@2024-03-01' = if (!infrastructureOnly){
+resource fileSystem 'Microsoft.StorageCache/amlFileSystems@2026-01-01' = if (!infrastructureOnly){
   name: '${name}-${uniqueString(resourceGroup().id,deployment().name)}'
   location: location
   tags: tags
@@ -42,7 +42,7 @@ resource fileSystem 'Microsoft.StorageCache/amlFileSystems@2024-03-01' = if (!in
 }
 
 // All fs modules must output ipAddress, exportPath and mountOptions
-output ipAddress string = infrastructureOnly ? '' : fileSystem.properties.clientInfo.mgsAddress
+output ipAddress string = infrastructureOnly ? '' : fileSystem!.properties.clientInfo.mgsAddress
 // TODO we are fighting the chef cookbooks here by adding tcp:/lustrefs, as it simply prepends all paths
 // with tcp:/lustrefs
 output exportPath string = '' //what should our placeholder be for new amlfs??

--- a/bicep/anf-account.bicep
+++ b/bicep/anf-account.bicep
@@ -3,7 +3,7 @@ targetScope = 'resourceGroup'
 param location string
 param resourcePostfix string = uniqueString(resourceGroup().id)
 
-resource anfAccount 'Microsoft.NetApp/netAppAccounts@2024-07-01' = {
+resource anfAccount 'Microsoft.NetApp/netAppAccounts@2025-12-01' = {
   name: 'hpcanfaccount-${take(resourcePostfix,10)}'
   location: location
 }

--- a/bicep/anf.bicep
+++ b/bicep/anf.bicep
@@ -18,7 +18,7 @@ resource anfAccount 'Microsoft.NetApp/netAppAccounts@2024-07-01' existing = if(!
   name: 'hpcanfaccount-${take(resourcePostfix,10)}'
 }
 
-resource anfPool 'Microsoft.NetApp/netAppAccounts/capacityPools@2025-06-01' = if(!infrastructureOnly){
+resource anfPool 'Microsoft.NetApp/netAppAccounts/capacityPools@2025-12-01' = if(!infrastructureOnly){
   name: '${name}-anf-pool'
   location: location
   tags: tags
@@ -32,7 +32,7 @@ resource anfPool 'Microsoft.NetApp/netAppAccounts/capacityPools@2025-06-01' = if
   } : {})
 }
 
-resource anfVolume 'Microsoft.NetApp/netAppAccounts/capacityPools/volumes@2025-06-01' = if(!infrastructureOnly){
+resource anfVolume 'Microsoft.NetApp/netAppAccounts/capacityPools/volumes@2025-12-01' = if(!infrastructureOnly){
   name: '${name}-anf-volume'
   location: location
   tags: tags
@@ -76,6 +76,6 @@ resource anfVolume 'Microsoft.NetApp/netAppAccounts/capacityPools/volumes@2025-0
 
 
 // Require fs_module outputs
-output ipAddress string = infrastructureOnly ? '' :anfVolume.properties.mountTargets[0].ipAddress
+output ipAddress string = infrastructureOnly ? '' :anfVolume!.properties.mountTargets[0].ipAddress
 output exportPath string = '/${name}-path'
 output mountOptions string = defaultMountOptions

--- a/bicep/bastion.bicep
+++ b/bicep/bastion.bicep
@@ -5,7 +5,7 @@ param location string
 param tags tags_t
 param subnetId string
 
-resource bastionPip 'Microsoft.Network/publicIpAddresses@2023-11-01' = {
+resource bastionPip 'Microsoft.Network/publicIpAddresses@2025-05-01' = {
   name: 'bastion-pip'
   location: location
   tags: tags
@@ -17,7 +17,7 @@ resource bastionPip 'Microsoft.Network/publicIpAddresses@2023-11-01' = {
   }
 }
 
-resource bastionHost 'Microsoft.Network/bastionHosts@2023-11-01' = {
+resource bastionHost 'Microsoft.Network/bastionHosts@2025-05-01' = {
   name: 'bastion'
   location: location
   tags: tags

--- a/bicep/ccw.bicep
+++ b/bicep/ccw.bicep
@@ -51,7 +51,7 @@ module ccwPublicKey './publicKey.bicep' = if (!useEnteredKey && !infrastructureO
     storedKey: storedKey
   }
 }
-var publicKey = infrastructureOnly ? '' : (useEnteredKey ? adminSshPublicKey : ccwPublicKey.outputs.publicKey)
+var publicKey = infrastructureOnly ? '' : (useEnteredKey ? adminSshPublicKey : ccwPublicKey!.outputs.publicKey)
 
 var createNatGateway = network.?createNatGateway ?? false
 module natgateway './natgateway.bicep' = if (createNatGateway) {
@@ -62,7 +62,7 @@ module natgateway './natgateway.bicep' = if (createNatGateway) {
     name: 'ccw-nat-gateway'
   }
 }
-var natGateawayId = createNatGateway ? natgateway.outputs.NATGatewayId : ''
+var natGateawayId = createNatGateway ? natgateway!.outputs.NATGatewayId : ''
 
 var create_new_vnet = network.type == 'new'
 module ccwNetwork './network-new.bicep' = if (create_new_vnet) {
@@ -80,7 +80,7 @@ module ccwNetwork './network-new.bicep' = if (create_new_vnet) {
 }
 
 var subnets = create_new_vnet
-  ? ccwNetwork.outputs.subnetsCCW
+  ? ccwNetwork!.outputs.subnetsCCW
   : {
       cyclecloud: join([network.?id, 'subnets', network.?cyclecloudSubnet], '/') 
       compute: join([network.?id, 'subnets', network.?computeSubnet], '/') 
@@ -92,7 +92,7 @@ var existingNetworkId = network.?id ?? 'a0a0a0a0/bbbb/cccc/dddd/eeee/ffff/aaaa/b
 
 output vnet types.networkOutput_t = {
   type: network.type
-  id: create_new_vnet ? ccwNetwork.outputs.vnetCCWId : existingNetworkId
+  id: create_new_vnet ? ccwNetwork!.outputs.vnetCCWId : existingNetworkId
   computeSubnetId: subnets.compute
 }
 
@@ -145,9 +145,6 @@ module ccwVM './vm.bicep' = if (!infrastructureOnly) {
       }
     ]
   }
-  dependsOn: [
-    ccwNetwork
-  ]
 }
 
 var miName = 'ccwLockerManagedIdentity'
@@ -156,7 +153,7 @@ module ccwManagedIdentity 'mi.bicep' = if (!infrastructureOnly) {
   params: {
     name: miName
     location: location
-    storageAccountName: ccwStorage.outputs.storageAccountName
+    storageAccountName: ccwStorage!.outputs.storageAccountName
     monitoringEnabled: monitoring.type == 'enabled'
     dcrId: monitoring.?dcrId ?? 'a0a0a0a0/bbbb/cccc/dddd/eeee/ffff/aaaa/bbbb/c8c8c8c8'
     tags: getTags('Microsoft.ManagedIdentity/userAssignedIdentities', tags)
@@ -173,11 +170,8 @@ module ccwRoleAssignments './vmRoleAssignments.bicep' = if (!infrastructureOnly)
       'Storage Blob Data Contributor'
       'Monitoring Metrics Publisher'
     ]
-    principalId: ccwVM.outputs.principalId
+    principalId: ccwVM!.outputs.principalId
   }
-  dependsOn: [
-    ccwVM
-  ]
 }
 
 module ccwStorage './storage.bicep' = {
@@ -218,9 +212,6 @@ module ccwAMLFS 'amlfs.bicep' = if (additionalFilesystem.type == 'aml-new') {
     availabilityZone:  additionalFilesystem.?availabilityZone ?? []
     infrastructureOnly: infrastructureOnly
   }
-  dependsOn: [
-    ccwNetwork
-  ]
 }
 
 module ccwANFAccount 'anf-account.bicep' = if((sharedFilesystem.type == 'anf-new' || additionalFilesystem.type == 'anf-new') && !infrastructureOnly) {
@@ -246,7 +237,6 @@ module ccwANF 'anf.bicep' = [
       infrastructureOnly: infrastructureOnly
     }
     dependsOn: [
-      ccwNetwork
       ccwANFAccount
     ]
   }
@@ -270,7 +260,7 @@ module oodNIC 'ood-NIC.bicep' = if (deployOOD) {
 
 // create a user assigned managed identity to be assigned to the OOD VM
 var oodManagedIdentityName = 'ccwOpenOnDemandManagedIdentity'
-resource oodNewManagedIdentity 'Microsoft.ManagedIdentity/userAssignedIdentities@2023-01-31' = if (createOODMI) {
+resource oodNewManagedIdentity 'Microsoft.ManagedIdentity/userAssignedIdentities@2024-11-30' = if (createOODMI) {
   name: oodManagedIdentityName
   location: location
 }
@@ -289,31 +279,31 @@ output filerInfoFinal types.filerInfo_t = {
   home: {
     type: sharedFilesystem.type
     nfsCapacityInGb: sharedFilesystem.?nfsCapacityInGb ?? -1
-    ipAddress: sharedFilesystem.type == 'anf-new' ? ccwANF[1].outputs.ipAddress : sharedFilesystem.?ipAddress ?? ''
-    exportPath: sharedFilesystem.type == 'anf-new' ? ccwANF[1].outputs.exportPath : sharedFilesystem.?exportPath ?? ''
+    ipAddress: sharedFilesystem.type == 'anf-new' ? ccwANF[1]!.outputs.ipAddress : sharedFilesystem.?ipAddress ?? ''
+    exportPath: sharedFilesystem.type == 'anf-new' ? ccwANF[1]!.outputs.exportPath : sharedFilesystem.?exportPath ?? ''
     mountOptions: sharedFilesystem.type == 'anf-new'
-      ? ccwANF[1].outputs.mountOptions
+      ? ccwANF[1]!.outputs.mountOptions
       : sharedFilesystem.?mountOptions ?? ''
     mountPath: '/shared'
   }
   additional: {
     type: additionalFilesystem.type
     ipAddress: additionalFilesystem.type == 'anf-new'
-      ? ccwANF[0].outputs.ipAddress
-      : additionalFilesystem.type == 'aml-new' ? ccwAMLFS.outputs.ipAddress : additionalFilesystem.?ipAddress ?? ''
+      ? ccwANF[0]!.outputs.ipAddress
+      : additionalFilesystem.type == 'aml-new' ? ccwAMLFS!.outputs.ipAddress : additionalFilesystem.?ipAddress ?? ''
     exportPath: additionalFilesystem.type == 'anf-new'
-      ? ccwANF[0].outputs.exportPath
+      ? ccwANF[0]!.outputs.exportPath
       :additionalFilesystem.?exportPath ?? ''
     mountOptions: additionalFilesystem.type == 'anf-new'
-      ? ccwANF[0].outputs.mountOptions
-      : additionalFilesystem.type == 'aml-new' ? ccwAMLFS.outputs.mountOptions : additionalFilesystem.?mountOptions ?? ''
+      ? ccwANF[0]!.outputs.mountOptions
+      : additionalFilesystem.type == 'aml-new' ? ccwAMLFS!.outputs.mountOptions : additionalFilesystem.?mountOptions ?? ''
     mountPath: additionalFilesystem.?mountPath ?? ''
   }
 }
 
-output cyclecloudPrincipalId string = infrastructureOnly ? '' : ccwVM.outputs.principalId
+output cyclecloudPrincipalId string = infrastructureOnly ? '' : ccwVM!.outputs.principalId
 
-output managedIdentityId string = infrastructureOnly ? '' : ccwManagedIdentity.outputs.managedIdentityId
+output managedIdentityId string = infrastructureOnly ? '' : ccwManagedIdentity!.outputs.managedIdentityId
 
 // Automatically inject the ccw cluster init spec
 
@@ -368,7 +358,7 @@ output tenantId string = subscription().tenantId
 // output databaseFQDN string = create_database ? mySQLccw.outputs.fqdn : ''
 output databaseInfo types.databaseOutput_t = databaseConfig.type != 'disabled' ?{
   databaseUser: databaseConfig.?databaseUser
-  url: databaseConfig.type == 'fqdn' ? databaseConfig.?fqdn : databaseConfig.type == 'privateIp' ? databaseConfig.?privateIp : ccwNetwork.outputs.?databaseFQDN 
+  url: databaseConfig.type == 'fqdn' ? databaseConfig.?fqdn : databaseConfig.type == 'privateIp' ? databaseConfig.?privateIp : ccwNetwork!.outputs.?databaseFQDN 
 } : {}
 output azureEnvironment string = envNameToCloudMap[environment().name]
 output nodeArrayTags types.tags_t = tags[?'Node Array'] ?? {}
@@ -393,7 +383,7 @@ output ood object = union(ood, {
 output oodManualRegistration object = {
   appName: oodAppName
   umiName: oodManagedIdentityName
-  fqdn: deployOOD ? oodNIC.outputs.privateIp : ''
+  fqdn: deployOOD ? oodNIC!.outputs.privateIp : ''
 }
 
 output monitoring object = {

--- a/bicep/entra/ccwEntraApp.bicep
+++ b/bicep/entra/ccwEntraApp.bicep
@@ -46,7 +46,7 @@ resource msGraphSP 'Microsoft.Graph/servicePrincipals@v1.0' existing = {
 var graphScopes = msGraphSP.oauth2PermissionScopes
 
 // Retrieve the user assigned managed identity assigned to the OOD VM
-resource ccwEntraManagedIdentity 'Microsoft.ManagedIdentity/userAssignedIdentities@2023-01-31' existing = {
+resource ccwEntraManagedIdentity 'Microsoft.ManagedIdentity/userAssignedIdentities@2024-11-30' existing = {
   name: umiName
 }
 
@@ -215,10 +215,6 @@ resource updateApplication 'Microsoft.Graph/applications@v1.0' = {
     'api://${clientAppId}'
   ]
   // end Expose an API section
-
-  dependsOn: [
-    ccwEntraApp
-  ]
 }
 
 resource servicePrincipal 'Microsoft.Graph/servicePrincipals@v1.0' = {

--- a/bicep/entra/ccwEntraApp.json
+++ b/bicep/entra/ccwEntraApp.json
@@ -81,7 +81,7 @@
     "ccwEntraManagedIdentity": {
       "existing": true,
       "type": "Microsoft.ManagedIdentity/userAssignedIdentities",
-      "apiVersion": "2023-01-31",
+      "apiVersion": "2024-11-30",
       "name": "[parameters('umiName')]"
     },
     "ccwEntraApp": {

--- a/bicep/mainTemplate.bicep
+++ b/bicep/mainTemplate.bicep
@@ -48,7 +48,7 @@ param oodProjectVersion string = '1.1.4'
 //Internal developer use only: set true use custom CycleCloud release build 
 param manualInstall bool = false
 
-resource ccwResourceGroup 'Microsoft.Resources/resourceGroups@2024-03-01' = {
+resource ccwResourceGroup 'Microsoft.Resources/resourceGroups@2025-03-01' = {
   name: resourceGroup
   location: location
   tags: tags[?'Resource group'] ?? {}

--- a/bicep/mi.bicep
+++ b/bicep/mi.bicep
@@ -9,7 +9,7 @@ param dcrId string
 param tags tags_t
 
 //create managed identity for VMSSs
-resource managedIdentity 'Microsoft.ManagedIdentity/userAssignedIdentities@2023-01-31' = {
+resource managedIdentity 'Microsoft.ManagedIdentity/userAssignedIdentities@2024-11-30' = {
   name: name
   location: location
   tags: tags

--- a/bicep/miRoleAssignments.bicep
+++ b/bicep/miRoleAssignments.bicep
@@ -5,7 +5,7 @@ param principalId string
 param roles array
 param storageAccountName string
 
-resource storageAccount 'Microsoft.Storage/storageAccounts@2023-04-01' existing = {
+resource storageAccount 'Microsoft.Storage/storageAccounts@2025-01-01' existing = {
   name: storageAccountName
 }
 

--- a/bicep/mysql.bicep
+++ b/bicep/mysql.bicep
@@ -19,7 +19,7 @@ param serverEdition string = 'Burstable'
 param skuName string = 'Standard_B2ms'
 
 // Create a MySQL Flexible Server
-resource server 'Microsoft.DBforMySQL/flexibleServers@2023-10-01-preview' = {
+resource server 'Microsoft.DBforMySQL/flexibleServers@2024-12-30' = {
   location: location
   tags: tags
   name: Name

--- a/bicep/natgateway.bicep
+++ b/bicep/natgateway.bicep
@@ -6,7 +6,7 @@ param tags tags_t
 param name string
 
 
-resource publicip 'Microsoft.Network/publicIPAddresses@2023-11-01' = {
+resource publicip 'Microsoft.Network/publicIPAddresses@2025-05-01' = {
   name: 'pip-${name}'
   location: location
   tags: tags
@@ -20,7 +20,7 @@ resource publicip 'Microsoft.Network/publicIPAddresses@2023-11-01' = {
   }
 }
 
-resource natgateway 'Microsoft.Network/natGateways@2023-11-01' = {
+resource natgateway 'Microsoft.Network/natGateways@2025-05-01' = {
   name: name
   location: location
   sku: {

--- a/bicep/network-new.bicep
+++ b/bicep/network-new.bicep
@@ -284,7 +284,7 @@ var peeredVnetId = network.?vnetToPeer.?id ?? 'a0a0a0a0/bbbb/cccc/dddd/eeee/ffff
 var peeredVnetName = split(peeredVnetId,'/')[8] 
 var peeredVnetResourceGroup = split(peeredVnetId,'/')[4]
 
-resource ccwCommonNsg 'Microsoft.Network/networkSecurityGroups@2025-05-01' = {
+resource ccwCommonNsg 'Microsoft.Network/networkSecurityGroups@2025-01-01' = {
   name: 'nsg-ccw-common'
   location: location
   tags: nsgTags
@@ -293,7 +293,7 @@ resource ccwCommonNsg 'Microsoft.Network/networkSecurityGroups@2025-05-01' = {
   }
 }
 
-resource ccwVirtualNetwork 'Microsoft.Network/virtualNetworks@2025-05-01' = {
+resource ccwVirtualNetwork 'Microsoft.Network/virtualNetworks@2025-01-01' = {
   name: vnet.name
   location: location
   tags: tags
@@ -325,7 +325,7 @@ resource ccwVirtualNetwork 'Microsoft.Network/virtualNetworks@2025-05-01' = {
   }
 }
 
-resource ccw_to_peer 'Microsoft.Network/virtualNetworks/virtualNetworkPeerings@2023-11-01' = if (peeringEnabled) {
+resource ccw_to_peer 'Microsoft.Network/virtualNetworks/virtualNetworkPeerings@2025-01-01' = if (peeringEnabled) {
   name: '${ccwVirtualNetwork.name}-to-${peeredVnetName}-${uniqueString(resourceGroup().id)}'
   parent: ccwVirtualNetwork
   properties: {
@@ -366,14 +366,14 @@ var subnets = union(
   createDatabase ? { database: subnetDatabaseId } : {}
 )
 
-resource ccwDatabase 'Microsoft.DBforMySQL/flexibleServers@2023-10-01-preview' existing = if (create_private_endpoint && databaseConfig.type != 'disabled') {
+resource ccwDatabase 'Microsoft.DBforMySQL/flexibleServers@2024-12-30' existing = if (create_private_endpoint && databaseConfig.type != 'disabled') {
   name: databaseConfig.?dbInfo.?name ?? 'disabled'
   scope: resourceGroup(split(databaseConfig.?dbInfo.?id ?? '////','/')[4])
 }
 
 var privateEndpointName = 'ccw-mysql-pe'
 
-resource privateEndpoint 'Microsoft.Network/privateEndpoints@2025-05-01' = if (create_private_endpoint) {
+resource privateEndpoint 'Microsoft.Network/privateEndpoints@2025-01-01' = if (create_private_endpoint) {
   name: privateEndpointName
   location: location
   properties: {
@@ -395,4 +395,4 @@ resource privateEndpoint 'Microsoft.Network/privateEndpoints@2025-05-01' = if (c
 output nsgCCWId string = ccwCommonNsg.id
 output vnetCCWId string = ccwVirtualNetwork.id
 output subnetsCCW types.subnets_t = subnets
-output databaseFQDN string = create_private_endpoint ? privateEndpoint.properties.customDnsConfigs[0].ipAddresses[0] : ''
+output databaseFQDN string = create_private_endpoint ? privateEndpoint!.properties.customDnsConfigs[0].ipAddresses[0] : ''

--- a/bicep/network-peering.bicep
+++ b/bicep/network-peering.bicep
@@ -12,11 +12,11 @@ param allowGateway bool = true
 @description('VNET Id of the ccw VNET')
 param vnetId string
 
-resource peeredVirtualNetwork 'Microsoft.Network/virtualNetworks@2023-11-01' existing = { 
+resource peeredVirtualNetwork 'Microsoft.Network/virtualNetworks@2025-01-01' existing = { 
   name: vnetName
 }
 
-resource peering 'Microsoft.Network/virtualNetworks/virtualNetworkPeerings@2023-11-01' = {
+resource peering 'Microsoft.Network/virtualNetworks/virtualNetworkPeerings@2025-01-01' = {
   name: name
   parent: peeredVirtualNetwork
   properties: {

--- a/bicep/ood-NIC.bicep
+++ b/bicep/ood-NIC.bicep
@@ -6,7 +6,7 @@ param location string
 param networkInterfacesTags types.tags_t
 param subnetId string
 
-resource nic 'Microsoft.Network/networkInterfaces@2023-11-01' = {
+resource nic 'Microsoft.Network/networkInterfaces@2025-01-01' = {
   name: '${name}-nic'
   location: location
   tags: networkInterfacesTags

--- a/bicep/publicKey.bicep
+++ b/bicep/publicKey.bicep
@@ -8,7 +8,7 @@ resource autogenerate_publickey 'Microsoft.Compute/sshPublicKeys@2023-09-01' = i
   location: location
 }
 */
-resource stored_publickey 'Microsoft.Compute/sshPublicKeys@2024-03-01' existing = {
+resource stored_publickey 'Microsoft.Compute/sshPublicKeys@2025-04-01' existing = {
   name: storedKey.name
   scope: resourceGroup(split(storedKey.id,'/')[4])
 }

--- a/bicep/roleAssignmentCleanup.bicep
+++ b/bicep/roleAssignmentCleanup.bicep
@@ -12,7 +12,7 @@ param roles array = [
 var subscriptionId = split(subscription().id, '/')[2]
 
 
-resource ccwResourceGroup 'Microsoft.Resources/resourceGroups@2024-03-01' = {
+resource ccwResourceGroup 'Microsoft.Resources/resourceGroups@2025-03-01' = {
   name: resourceGroup
   location: location
 }

--- a/bicep/storage.bicep
+++ b/bicep/storage.bicep
@@ -12,7 +12,7 @@ var privateDnsZoneResourceGroup = split(privateDnsZoneId, '/')[4]
 var createVnetLink = storagePrivateDnsZone.type == 'existing' ? storagePrivateDnsZone.vnetLink : storagePrivateDnsZone.type == 'new'
 var vnetLinkScope = contains(storagePrivateDnsZone,'id') ? split(privateDnsZoneId, '/')[4] : az.resourceGroup().name
 
-resource storageAccount 'Microsoft.Storage/storageAccounts@2024-01-01' = {
+resource storageAccount 'Microsoft.Storage/storageAccounts@2025-06-01' = {
   name: saName
   location: location
   tags: tags
@@ -34,7 +34,7 @@ resource storageAccount 'Microsoft.Storage/storageAccounts@2024-01-01' = {
 
 var storageBlobPrivateEndpointName = 'ccwstorage-blob-pe'
 
-resource storageBlobPrivateEndpoint 'Microsoft.Network/privateEndpoints@2024-05-01' = {
+resource storageBlobPrivateEndpoint 'Microsoft.Network/privateEndpoints@2025-05-01' = {
   name: storageBlobPrivateEndpointName
   location: location
   tags: tags
@@ -83,12 +83,12 @@ module blobPrivateDnsZoneVnetLink 'storage-vnetLink.bicep' = if (createVnetLink)
   params: {
     storageAccountId: storageAccount.id
     subnetId: subnetId
-    blobPrivateDnsZoneName: storagePrivateDnsZone.type == 'existing' ? blobPrivateDnsZone.name : newBlobPrivateDnsZone.outputs.blobPrivateDnsZoneName //force dependency
+    blobPrivateDnsZoneName: storagePrivateDnsZone.type == 'existing' ? blobPrivateDnsZone.name : newBlobPrivateDnsZone!.outputs.blobPrivateDnsZoneName //force dependency
     tags: tags
   }
 }
 
-resource privateEndpointDns 'Microsoft.Network/privateEndpoints/privateDnsZoneGroups@2024-05-01' = if (storagePrivateDnsZone.type != 'none') {
+resource privateEndpointDns 'Microsoft.Network/privateEndpoints/privateDnsZoneGroups@2025-05-01' = if (storagePrivateDnsZone.type != 'none') {
   parent: storageBlobPrivateEndpoint
   name: 'default'
   properties:{
@@ -96,7 +96,7 @@ resource privateEndpointDns 'Microsoft.Network/privateEndpoints/privateDnsZoneGr
       {
         name: blobPrivateDnsZoneName
         properties:{
-          privateDnsZoneId: storagePrivateDnsZone.type == 'existing' ? blobPrivateDnsZone.id : newBlobPrivateDnsZone.outputs.blobPrivateDnsZoneId
+          privateDnsZoneId: storagePrivateDnsZone.type == 'existing' ? blobPrivateDnsZone.id : newBlobPrivateDnsZone!.outputs.blobPrivateDnsZoneId
         }
       }
     ]

--- a/bicep/vm.bicep
+++ b/bicep/vm.bicep
@@ -19,7 +19,7 @@ param vmSize string
 param dataDisks array
 param osDiskSize int = 0 //TODO: add to UI
 
-resource nic 'Microsoft.Network/networkInterfaces@2023-11-01' = {
+resource nic 'Microsoft.Network/networkInterfaces@2025-05-01' = {
   name: '${name}-nic'
   location: location
   tags: networkInterfacesTags
@@ -39,7 +39,7 @@ resource nic 'Microsoft.Network/networkInterfaces@2023-11-01' = {
   }
 }
 
-resource virtualMachine 'Microsoft.Compute/virtualMachines@2024-03-01' = {
+resource virtualMachine 'Microsoft.Compute/virtualMachines@2025-04-01' = {
   name: name
   location: location
   tags: tags
@@ -114,7 +114,7 @@ resource virtualMachine 'Microsoft.Compute/virtualMachines@2024-03-01' = {
   }
 }
 
-resource cse 'Microsoft.Compute/virtualMachines/extensions@2024-03-01' = {
+resource cse 'Microsoft.Compute/virtualMachines/extensions@2025-04-01' = {
   name: '${name}-customScriptExtension'
   location: location
   parent: virtualMachine

--- a/build.sh
+++ b/build.sh
@@ -51,4 +51,4 @@ pushd "$build_dir"
 zip -j "${GIT_ROOT}/build.zip" ./*
 popd
 
-${THIS_DIR}/arm-ttk/arm-ttk/Test-AzTemplate.sh $build_dir # -Skip Parameter-Types-Should-Be-Consistent
+${THIS_DIR}/arm-ttk/arm-ttk/Test-AzTemplate.sh $build_dir -Skip apiVersions-Should-Be-Recent 

--- a/util/install-arm-ttk.sh
+++ b/util/install-arm-ttk.sh
@@ -35,7 +35,8 @@ if [ -d "$GIT_ROOT/arm-ttk" ]; then
     exit 0
 fi
 
-wget https://github.com/Azure/arm-ttk/releases/download/20240328/arm-ttk.zip
+LATEST_VERSION=$(curl -s https://api.github.com/repos/Azure/arm-ttk/releases/latest | sed -n 's/.*"tag_name"[[:space:]]*:[[:space:]]*"\([^"]*\)".*/\1/p')
+wget "https://github.com/Azure/arm-ttk/releases/download/${LATEST_VERSION}/arm-ttk.zip"
 unzip -u arm-ttk.zip -d $GIT_ROOT
 rm arm-ttk.zip
 chmod +x $GIT_ROOT/arm-ttk/arm-ttk/Test-AzTemplate.sh


### PR DESCRIPTION
This code change does the following: 

1. Updates all API versions to the most recent recognised by the Bicep linter 
2. Adds null-forgiving operators where needed
3. Suppresses API version checks in ARM-TTK, as it is out of sync with the latest API versions
4. Ensures GitHub action always uses the latest ARM-TTK