### PR TITLE
Revisions to Entra and OOD menus

### DIFF
--- a/bicep/types.bicep
+++ b/bicep/types.bicep
@@ -9,7 +9,6 @@ type entra_enabled_t = {
   type: 'enabled'
   tenantId: string
   clientId: string
-  managedIdentityId: string
 }
 
 @discriminator('type')

--- a/uidefinitions/createUiDefinition.json
+++ b/uidefinitions/createUiDefinition.json
@@ -374,18 +374,6 @@
         }
       },
       {
-        "name": "entraManagedIdentity",
-        "type": "Microsoft.Solutions.ResourceSelector",
-        "label": "Managed Identity",
-        "toolTip": "Select the user-assigned managed identity created for the federated credentials associated with the application registration",
-        "resourceType": "Microsoft.ManagedIdentity/userAssignedIdentities",
-        "constraints": {
-          "required": true,
-          "validationMessage": "Please select a managed identity."
-        },
-        "visible": "[basics('enableEntra')]"
-      },
-      {
         "name": "tenantId",
         "type": "Microsoft.Common.TextBox",
         "label": "Tenant ID",
@@ -2472,6 +2460,18 @@
                 }
               },
               {
+                "name": "oodManagedIdentity",
+                "type": "Microsoft.Solutions.ResourceSelector",
+                "label": "Managed Identity",
+                "toolTip": "Select the user-assigned managed identity created for the federated credentials associated with the application registration",
+                "resourceType": "Microsoft.ManagedIdentity/userAssignedIdentities",
+                "constraints": {
+                  "required": true,
+                  "validationMessage": "Please select a managed identity."
+                },
+                "visible": "[and(steps('ood').OODSection.deployOOD,basics('enableEntra'))]"
+              },
+              {
                 "name": "startClusterInfo",
                 "type": "Microsoft.Common.InfoBox",
                 "visible": "[and(not(equals(steps('ood').OODSection.registerEntraIDApp,'manual')),steps('ood').OODSection.startCluster,basics('enableEntra'))]",
@@ -2760,9 +2760,7 @@
       "entraIdInfo": {
         "type": "[if(basics('enableEntra'),'enabled','disabled')]",
         "tenantId": "[if(basics('enableEntra'),basics('tenantId'),basics('nullValue'))]",
-        "clientId": "[if(basics('enableEntra'),basics('clientId'),basics('nullValue'))]",
-        "managedIdentityId": "[if(basics('enableEntra'),basics('entraManagedIdentity').id,basics('nullValue'))]"
-      },
+        "clientId": "[if(basics('enableEntra'),basics('clientId'),basics('nullValue'))]"      },
       "schedFilesystem": {
         "type": "[concat(if(equals(steps('filesystem').sched.newexisting,'new'),steps('filesystem').sched.filertype,'nfs'),'-',steps('filesystem').sched.newexisting)]",
         "nfsCapacityInGb": "[if(equals(steps('filesystem').sched.filertype,'nfs'),int(steps('filesystem').sched.nfscapacity),basics('nullValue'))]",
@@ -2871,7 +2869,7 @@
         "registerEntraIDApp": "[if(and(steps('ood').OODSection.deployOOD,basics('enableEntra')),equals(steps('ood').OODSection.registerEntraIDApp,'autoregister'),basics('nullValue'))]",
         "appTenantId": "[if(and(steps('ood').OODSection.deployOOD,basics('enableEntra')),basics('tenantId'),basics('nullValue'))]",
         "appId": "[if(and(steps('ood').OODSection.deployOOD,basics('enableEntra')),basics('clientId'),basics('nullValue'))]",
-        "appManagedIdentityId": "[if(and(steps('ood').OODSection.deployOOD,basics('enableEntra')),basics('entraManagedIdentity').id,basics('nullValue'))]"
+        "appManagedIdentityId": "[if(and(steps('ood').OODSection.deployOOD,basics('enableEntra')),steps('ood').OODSection.oodManagedIdentity.id,basics('nullValue'))]"
       },
       "monitoring": {
         "type": "[if(steps('advancedSettings').monitoringSection.monitoringEnabled,'enabled','disabled')]",

--- a/uidefinitions/createUiDefinition.json
+++ b/uidefinitions/createUiDefinition.json
@@ -374,19 +374,6 @@
         }
       },
       {
-        "name": "tenantId",
-        "type": "Microsoft.Common.TextBox",
-        "label": "Tenant ID",
-        "defaultValue": "",
-        "toolTip": "Tenant ID of the Entra ID application registration",
-        "constraints": {
-          "required": true,
-          "regex": "^[0-9a-fA-F]{8}-([0-9a-fA-F]{4}-){3}[0-9a-fA-F]{12}$",
-          "validationMessage": "Enter a valid tenant ID"
-        },
-        "visible": "[basics('enableEntra')]"
-      },
-      {
         "name": "clientId",
         "type": "Microsoft.Common.TextBox",
         "label": "Application (client) ID",
@@ -396,6 +383,19 @@
           "required": true,
           "regex": "^[0-9a-fA-F]{8}-([0-9a-fA-F]{4}-){3}[0-9a-fA-F]{12}$",
           "validationMessage": "Enter a valid client ID"
+        },
+        "visible": "[basics('enableEntra')]"
+      },
+      {
+        "name": "tenantId",
+        "type": "Microsoft.Common.TextBox",
+        "label": "Tenant ID",
+        "defaultValue": "",
+        "toolTip": "Tenant ID of the Entra ID application registration",
+        "constraints": {
+          "required": true,
+          "regex": "^[0-9a-fA-F]{8}-([0-9a-fA-F]{4}-){3}[0-9a-fA-F]{12}$",
+          "validationMessage": "Enter a valid tenant ID"
         },
         "visible": "[basics('enableEntra')]"
       },

--- a/uidefinitions/createUiDefinition.json
+++ b/uidefinitions/createUiDefinition.json
@@ -2250,7 +2250,7 @@
                 "type": "Microsoft.Common.CheckBox",
                 "label": "Deploy Open OnDemand",
                 "toolTip": "Deploy Open OnDemand alongside the Slurm cluster",
-                "defaultValue": true,
+                "defaultValue": false,
                 "constraints": {
                   "required": false
                 },


### PR DESCRIPTION
1. Moves the managed identity selection to the OOD page 
2. Switches the order of the Tenant ID and Client ID fields on the Basics page to match app registrations
3. Disables OOD by default; makes the feature opt-in